### PR TITLE
Removing rewrite rules for firebase

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,12 +1,6 @@
 {
   "hosting": {
     "public": "dist",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
-    ]
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
   }
 }


### PR DESCRIPTION
I suspect they're conflicting with proper 404 handling.