### PR TITLE
Moving title logic to a global mixin

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -27,6 +27,7 @@ export default {
     ],
   },
   modules: ['@nuxtjs/sitemap', '@nuxtjs/robots'],
+  plugins: ['~/plugins/head'],
   sitemap: {
     hostname: 'https://hello-world-vue-static.web.app/',
     gzip: true,

--- a/pages/counter.vue
+++ b/pages/counter.vue
@@ -13,14 +13,10 @@
 
 <script>
 export default {
-  head: {
-    title: 'Counter',
-    meta: [
-      {
-        property: 'og:title',
-        content: 'Counter',
-      },
-    ],
+  asyncData() {
+    return {
+      title: 'Counter',
+    };
   },
   data: function() {
     return {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,14 +12,10 @@
 
 <script>
 export default {
-  head: {
-    title: 'Home page',
-    meta: [
-      {
-        property: 'og:title',
-        content: 'Home page',
-      },
-    ],
+  asyncData() {
+    return {
+      title: 'Home page',
+    };
   },
 };
 </script>

--- a/plugins/head.js
+++ b/plugins/head.js
@@ -1,0 +1,15 @@
+import Vue from 'vue';
+
+Vue.mixin({
+  data() {
+    return {
+      title: null,
+    };
+  },
+  head() {
+    return {
+      title: this.title,
+      meta: [{hid: 'og:title', property: 'og:title', content: this.title}],
+    };
+  },
+});


### PR DESCRIPTION
This saves us from having to redundantly define title and og:title on every page.